### PR TITLE
Remove duplicate TLS metrics

### DIFF
--- a/collector/core_tcp_info.go
+++ b/collector/core_tcp_info.go
@@ -35,8 +35,6 @@ func init() {
 type coreTCPInfoCollector struct {
 	tcpReaders        *prometheus.Desc
 	tcpMaxConnections *prometheus.Desc
-	tlsMaxConnections *prometheus.Desc
-	tlsConnections    *prometheus.Desc
 	logger            log.Logger
 	config            *KamailioCollectorConfig
 }
@@ -51,14 +49,6 @@ func NewCoreTCPInfoCollector(config *KamailioCollectorConfig, logger log.Logger)
 		tcpMaxConnections: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "tcp_max_connections"),
 			"TCP connection limit",
-			[]string{}, nil),
-		tlsMaxConnections: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "tls_max_connections"),
-			"TLS connection limit",
-			[]string{}, nil),
-		tlsConnections: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "", "tls_connections"),
-			"Opened TLS connections",
 			[]string{}, nil),
 		config: config,
 		logger: logger,
@@ -82,12 +72,6 @@ func (c *coreTCPInfoCollector) Update(conn net.Conn, metricChannel chan<- promet
 		case "max_connections":
 			v, _ = item.Value.Int()
 			metricChannel <- prometheus.MustNewConstMetric(c.tcpMaxConnections, prometheus.GaugeValue, float64(v))
-		case "max_tls_connections":
-			v, _ = item.Value.Int()
-			metricChannel <- prometheus.MustNewConstMetric(c.tlsMaxConnections, prometheus.GaugeValue, float64(v))
-		case "opened_tls_connections":
-			v, _ = item.Value.Int()
-			metricChannel <- prometheus.MustNewConstMetric(c.tlsConnections, prometheus.GaugeValue, float64(v))
 		}
 	}
 	return nil


### PR DESCRIPTION
This ignores the TLS metrics returned by the ``core.tcp_info`` command, because these conflict with the metrics returned by the ``tls.info`` command.

```
collected metric "kamailio_tls_max_connections" { gauge:{value:2048}} was collected before with the same name and label values
```